### PR TITLE
Fix two errors in Ultimate Challenge's map definitions.

### DIFF
--- a/Common/MapInfo.txt
+++ b/Common/MapInfo.txt
@@ -1042,7 +1042,7 @@ map SD312 "Satellite Systems: Floor 12"
 	par = 270
 	next = SD313
 	levelnum = 312
-	secretnext = RTD20
+	secretnext = SD320
 }
 
 map SD313 "Satellite Systems: Floor 13"
@@ -1097,8 +1097,8 @@ map SD319 "Secret 1: Floor 19"
 {
 	music = XJAZNAZI
 	par = 0
-	next = RTD05
-	secretnext = RTD05
+	next = SD305
+	secretnext = SD305
 	levelnum = 319
 }
 


### PR DESCRIPTION
Game no longer crash when exiting SD319 (Floor 19, Secret level 1) and secret exit in SD312 (Floor 12) works properly and brings the player to the second secret level, instead of Floor 13.